### PR TITLE
Upgrade Reqwest Version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "recaptcha"
 description = "recaptcha response verification"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["panicbit <panicbit.dev@gmail.com>"]
 license = "MIT"
 keywords = ["recaptcha", "captcha"]
 repository = "https://github.com/panicbit/recaptcha-rs"
 
 [dependencies]
-reqwest = "0.8.8"
+reqwest = "0.9.7"
 serde_derive = "1.0.76"
 serde = "1.0.76"
 failure = "0.1.2"


### PR DESCRIPTION
The reqwest version used by the library uses an older version of
OpenSSL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/recaptcha-rs/4)
<!-- Reviewable:end -->
