### PR TITLE
update to tokio 1 and reqwest 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "recaptcha"
 description = "recaptcha response verification"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["panicbit <panicbit.dev@gmail.com>"]
 license = "MIT"
 keywords = ["recaptcha", "captcha"]
@@ -14,11 +14,11 @@ default = ["reqwest/default-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
-reqwest = { version = "0.10.4", features = ["json"], default-features = false }
+reqwest = { version = "0.11", features = ["json"], default-features = false }
 serde_derive = "1.0.106"
 serde = "1.0.106"
 failure = "0.1.7"
 
 [dev-dependencies]
 serde_json = "1.0.50"
-tokio = { version = "0.2.15", features = ["macros"] }
+tokio = { version = "1", features = ["macros"] }


### PR DESCRIPTION
Tokio 1 cannot be part of the same binary as tokio 0.2, so this PR is needed for any binaries wishing to use recaptcha that already use tokio 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/recaptcha-rs/14)
<!-- Reviewable:end -->
