### PR TITLE
Gortavoher/editiion-dependency-updates

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,12 @@
+{
+  "scanSettings": {
+    "baseBranches": []
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure",
+    "displayMode": "diff"
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW"
+  }
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 reqwest = { version = "0.11.23", features = ["json"], default-features = false }
 serde_derive = "1.0.106"
 serde = "1.0.106"
-failure = "0.1.7"
+thiserror = "1.0.52"
 
 [dev-dependencies]
 serde_json = "1.0.50"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["panicbit <panicbit.dev@gmail.com>"]
 license = "MIT"
 keywords = ["recaptcha", "captcha"]
 repository = "https://github.com/panicbit/recaptcha-rs"
-edition = "2018"
+edition = "2021"
 
 [features]
 
@@ -14,11 +14,11 @@ default = ["reqwest/default-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
-reqwest = { version = "0.10.4", features = ["json"], default-features = false }
+reqwest = { version = "0.11.23", features = ["json"], default-features = false }
 serde_derive = "1.0.106"
 serde = "1.0.106"
 failure = "0.1.7"
 
 [dev-dependencies]
 serde_json = "1.0.50"
-tokio = { version = "0.2.15", features = ["macros"] }
+tokio = { version = "1.35.1", features = ["macros"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,3 @@
-extern crate reqwest;
-extern crate serde;
-#[macro_use] extern crate serde_derive;
-#[macro_use] extern crate failure;
-
 pub mod error;
 mod response;
 
@@ -14,18 +9,14 @@ use reqwest::Url;
 use response::RecaptchaResponse;
 
 pub use error::Error;
-
-
 /// Verify a recaptcha user response
 pub async fn verify(key: &str, response: &str, user_ip: Option<&IpAddr>) -> Result<(), Error> {
     let user_ip = user_ip.map(ToString::to_string);
 
     let mut url = Url::parse("https://www.google.com/recaptcha/api/siteverify").unwrap();
 
-    url.query_pairs_mut().extend_pairs(&[
-        ("secret", key),
-        ("response", response),
-    ]);
+    url.query_pairs_mut()
+        .extend_pairs(&[("secret", key), ("response", response)]);
 
     if let Some(user_ip) = user_ip {
         url.query_pairs_mut().append_pair("remoteip", &user_ip);
@@ -37,7 +28,7 @@ pub async fn verify(key: &str, response: &str, user_ip: Option<&IpAddr>) -> Resu
     match (recaptcha_response.success, recaptcha_response.error_codes) {
         (true, _) => Ok(()),
         (false, Some(errors)) => Err(Error::Codes(errors)),
-        (false, _) => Err(Error::Codes(HashSet::new()))
+        (false, _) => Err(Error::Codes(HashSet::new())),
     }
 }
 
@@ -47,8 +38,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_invalid_secret_missing_response() {
-        use error::Error::*;
         use error::Code::*;
+        use error::Error::*;
         let response = verify("", "", None).await;
 
         match response {

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,11 +1,12 @@
-use std::collections::HashSet;
 use crate::error::Code;
+use serde_derive::Deserialize;
+use std::collections::HashSet;
 
 #[derive(Debug, Deserialize)]
 pub struct RecaptchaResponse {
     pub success: bool,
-    #[serde(rename="error-codes")]
-    pub error_codes: Option<HashSet<Code>>
+    #[serde(rename = "error-codes")]
+    pub error_codes: Option<HashSet<Code>>,
 }
 
 #[cfg(test)]
@@ -14,8 +15,8 @@ mod tests {
 
     #[test]
     fn decoding_test() {
-        use serde_json::json;
         use crate::error::Code::*;
+        use serde_json::json;
 
         let response = json!({
             "success": true,


### PR DESCRIPTION
- Update edition to 2021
- Update dependencies 
- Remove extern crate and macro_use as no longer required.
- add use for serde_derive in response .
-  replace failure crate with thiserror (failure no longer maintained)
- Update error handling to use thiserror

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/recaptcha-rs/16)
<!-- Reviewable:end -->
